### PR TITLE
Use delete[] for arrays deallocation

### DIFF
--- a/MoParser.cpp
+++ b/MoParser.cpp
@@ -39,8 +39,8 @@ int32_t GettextMoParser::swap_(int32_t ui) const {
 
 
 void GettextMoParser::clearData() {
-  if (moData_) delete moData_;
-  if (charset_) delete charset_;
+  if (moData_) delete[] moData_;
+  if (charset_) delete[] charset_;
 
   swappedBytes_ = false;
   moFileHeader_ = NULL;
@@ -51,12 +51,12 @@ void GettextMoParser::clearData() {
   for (int i = 0; i < (int)messages_.size(); i++) {
     TranslatedMessage* message = messages_.at(i);
     if (message->original) {
-    delete[] message->original->string;
-    delete message->original;
+      delete[] message->original->string;
+      delete message->original;
     }
     if (message->translated) {
-    delete[] message->translated->string;
-    delete message->translated;
+      delete[] message->translated->string;
+      delete message->translated;
     }
     delete message;
   }


### PR DESCRIPTION
Hello, I tried the code with C++Builder and enabled the memory reporting tool.
I'm getting an error similar to this: The array created with new[] must use delete[].

Example from _MoParser.cpp_:
```cpp
  charset_ = new char[charsetLength + 1];
```
So we must use:
```cpp
  if (charset_) delete[] charset_;
```

I also corrected a small indentation problem with code in **if** condition.