### PR TITLE
Correct possible memory leak

### DIFF
--- a/MoParser.cpp
+++ b/MoParser.cpp
@@ -22,7 +22,7 @@ const int32_t GettextMoParser::HEADER_MAGIC_NUMBER_SW = 0xde120495;
 
 
 GettextMoParser::GettextMoParser() {
-	swappedBytes_ = false;
+  swappedBytes_ = false;
   moFileHeader_ = NULL;
   moData_ = NULL;
   charset_ = NULL;
@@ -82,6 +82,7 @@ bool GettextMoParser::parseFile(const char* filePath) {
   ifstream moFile(filePath, ios::in | ios::binary);
   if (!moFile.read(moData, fileInfo.st_size)) {
     // Cannot read file data
+    delete[] moData;
     clearData();
     return false;
   }


### PR DESCRIPTION
In the **GettextMoParser::parseFile** method, on line 80 a new char array is created for **moData**. So if an error is found, the memory must be freed before exiting.

Instead of deleting the memory, the **moData_** variable could have been set to **moData** and let **clearData()** do is job, but I prefer my fix since it's easier to understand.

This error was reported by [Cppcheck](http://cppcheck.sourceforge.net).