### PR TITLE
Possible crash in the getTranslation function when originalString is not null terminated

### DIFF
--- a/LauGettext.cpp
+++ b/LauGettext.cpp
@@ -14,7 +14,7 @@
 #endif
 
 #include <fstream>
-#include <iostream> 
+#include <iostream>
 
 LauGettext* LauGettext::instance_ = NULL;
 

--- a/LauGettext.h
+++ b/LauGettext.h
@@ -30,7 +30,7 @@ public:
   inline std::string catalogueName() const { return catalogueName_; }
   inline std::string catalogueLocation() const { return catalogueLocation_; }
 
-  GettextMessage* getTranslation(const char* originalString, int originalLength) const; 
+  GettextMessage* getTranslation(const char* originalString, int originalLength) const;
 
 protected:
 

--- a/MoParser.cpp
+++ b/MoParser.cpp
@@ -204,7 +204,7 @@ GettextMessage* GettextMoParser::getTranslation(const char* originalString, int 
   
 
   char* originalStringCopy = new char[originalLength + 1];
-  strcpy(originalStringCopy, originalString);
+  strncpy(originalStringCopy, originalString, originalLength);
   originalStringCopy[originalLength] = '\0';
 
   GettextMessage* mOriginal = new GettextMessage();

--- a/MoParser.cpp
+++ b/MoParser.cpp
@@ -68,7 +68,7 @@ void GettextMoParser::clearData() {
 
 bool GettextMoParser::parseFile(const char* filePath) {
   clearData();
-  
+
   struct stat fileInfo;
 
   if (stat(filePath, &fileInfo) != 0) {
@@ -126,7 +126,7 @@ GettextMoParser::~GettextMoParser() {
 
 char* GettextMoParser::charset() const {
   if (charset_ || charsetParsed_) return charset_;
-  if (!moData_) return NULL;  
+  if (!moData_) return NULL;
 
   charsetParsed_ = true;
 
@@ -138,17 +138,17 @@ char* GettextMoParser::charset() const {
   std::string info(infoBuffer);
   size_t contentTypePos = info.find("Content-Type: text/plain; charset=");
   if (contentTypePos == info.npos) return NULL;
-  
+
   size_t stringStart = contentTypePos + 34; // strlen("Content-Type: text/plain; charset=")
   size_t stringEnd = info.find('\n', stringStart);
   if (stringEnd == info.npos) return NULL;
-  
+
   int charsetLength = stringEnd - stringStart;
   if (charsetLength == 0) return NULL;
 
   charset_ = new char[charsetLength + 1];
   info.copy(charset_, charsetLength, stringStart);
-  
+
   charset_[charsetLength] = '\0';
 
   if (strcmp(charset_, "CHARSET") == 0) {
@@ -182,7 +182,7 @@ GettextMessage* GettextMoParser::getTranslation(const char* originalString, int 
   MoOffsetTableItem* originalTable = (MoOffsetTableItem*)(moData_ + moFileHeader_->offsetOriginalStrings);
   originalTable->length = swap_(originalTable->length);
   originalTable->offset = swap_(originalTable->offset);
-  
+
   int stringIndex;
   bool found = false;
 
@@ -193,7 +193,7 @@ GettextMessage* GettextMoParser::getTranslation(const char* originalString, int 
       found = true;
       break;
     }
-    
+
     originalTable++;
     originalTable->length = swap_(originalTable->length);
     originalTable->offset = swap_(originalTable->offset);
@@ -201,7 +201,7 @@ GettextMessage* GettextMoParser::getTranslation(const char* originalString, int 
 
 
   TranslatedMessage* message = new TranslatedMessage();
-  
+
 
   char* originalStringCopy = new char[originalLength + 1];
   strncpy(originalStringCopy, originalString, originalLength);
@@ -236,11 +236,11 @@ GettextMessage* GettextMoParser::getTranslation(const char* originalString, int 
   strncpy(translatedString, tempString, translationTable->length);
   translatedString[translationTable->length] = '\0';
 
-  
+
   GettextMessage* mTranslated = new GettextMessage();
   mTranslated->length = translationTable->length;
   mTranslated->string = translatedString;
-  
+
   message->translated = mTranslated;
 
   messages_.push_back(message);

--- a/MoParser.h
+++ b/MoParser.h
@@ -41,7 +41,7 @@ public:
   bool parseFile(const char* filePath);
   bool parse(char* moData);
   void clearData();
-  GettextMessage* getTranslation(const char* originalString, int originalLength); 
+  GettextMessage* getTranslation(const char* originalString, int originalLength);
   char* charset() const;
   inline bool ready() const { return ready_; }
 

--- a/QtGettext.cpp
+++ b/QtGettext.cpp
@@ -75,12 +75,12 @@ QString QtGettext::getTranslation(const QString& originalString) const {
     return QString::fromUcs4(temp, message->length);
   }
 
-  return QString::fromUtf8(message->string); 
+  return QString::fromUtf8(message->string);
 }
 
 
 void QtGettext::setCatalogueName(const QString& name) {
-  LauGettext::setCatalogueName(name.toAscii().data()); // name.toStdString());  
+  LauGettext::setCatalogueName(name.toAscii().data()); // name.toStdString());
 }
 
 

--- a/QtGettext.h
+++ b/QtGettext.h
@@ -35,7 +35,7 @@ public:
   inline QString catalogueName() const { return QString::fromAscii(LauGettext::catalogueName().c_str()); }
   inline QString catalogueLocation() const { return QString::fromAscii(LauGettext::catalogueLocation().c_str()); }
 
-  QString getTranslation(const QString& originalString) const; 
+  QString getTranslation(const QString& originalString) const;
   QStringList availableLocales() const;
 
   QString charset() const;

--- a/QtLocaleUtil.cpp
+++ b/QtLocaleUtil.cpp
@@ -148,7 +148,7 @@ QtLocaleUtil::QtLocaleUtil() {
     codeToLanguageE_["za"] = "Zhuang";
     codeToLanguageE_["zh"] = "Chinese";
     codeToLanguageE_["zu"] = "Zulu";
-  
+
   codeToLanguage_["an"] = "Aragonés";
   codeToLanguage_["da"] = "Dansk";
   codeToLanguage_["de"] = "Deutsch";
@@ -166,18 +166,18 @@ QtLocaleUtil::QtLocaleUtil() {
   codeToLanguage_["sq"] = "Shqip";
   codeToLanguage_["sr"] = "српски језик";
   codeToLanguage_["tr"] = "Türkçe";
-  codeToLanguage_["ja"] = "日本語";  
+  codeToLanguage_["ja"] = "日本語";
   codeToLanguage_["ko"] = "한국말";
-  codeToLanguage_["sv"] = "Svenska";    
-  codeToLanguage_["el"] = "ελληνικά";    
+  codeToLanguage_["sv"] = "Svenska";
+  codeToLanguage_["el"] = "ελληνικά";
   codeToLanguage_["zh"] = "中文";
-  codeToLanguage_["ro"] = "Română"; 
-  codeToLanguage_["et"] = "Eesti Keel"; 
-  codeToLanguage_["vi"] = "Tiếng Việt"; 
-  codeToLanguage_["hu"] = "Magyar"; 
-  
-  codeToCountry_["BR"] = "Brasil"; 
-  codeToCountry_["CN"] = "中国"; 
+  codeToLanguage_["ro"] = "Română";
+  codeToLanguage_["et"] = "Eesti Keel";
+  codeToLanguage_["vi"] = "Tiếng Việt";
+  codeToLanguage_["hu"] = "Magyar";
+
+  codeToCountry_["BR"] = "Brasil";
+  codeToCountry_["CN"] = "中国";
 }
 
 
@@ -194,7 +194,7 @@ QString QtLocaleUtil::getDisplayName(const QString& canonicalName) const {
       extraString = "简体"; // "Simplified" in "Simplified Chinese"
     } else {
       extraString = getCountryName(countryCode);
-    }    
+    }
   }
 
   if (languageCode == "zh" && (countryCode == "" || countryCode == "TW")) extraString = "繁體"; // "Traditional" in "Traditional Chinese"

--- a/QtLocaleUtil.h
+++ b/QtLocaleUtil.h
@@ -14,7 +14,7 @@
 class QtLocaleUtil {
 
 public:
-	
+
   QtLocaleUtil();
   QString getDisplayName(const QString& canonicalName) const;
   QString getLanguageName(const QString& languageCode, bool defaultToEnglish = true) const;
@@ -22,7 +22,7 @@ public:
   QString getLanguageCodeOnly(const QString& canonicalName) const;
   QString getCountryCodeOnly(const QString& canonicalName) const;
   QString getCountryName(const QString& countryCode) const;
-	
+
 private:
 
   mutable std::map<QString, QString> codeToLanguage_;


### PR DESCRIPTION
Hello, if the string `originalString` is not null terminated it will crash the application. I was getting an access violation in my code.

The solution was to use `strncpy` with `originalLength` instead of `strcpy`.

I have also removed all trailing spaces in the code.